### PR TITLE
fix: fix RUnlock timing

### DIFF
--- a/deadlock.go
+++ b/deadlock.go
@@ -115,10 +115,10 @@ func (m *RWMutex) RLock() {
 // It is a run-time error if rw is not locked for reading
 // on entry to RUnlock.
 func (m *RWMutex) RUnlock() {
+	m.mu.RUnlock()
 	if !Opts.Disable {
 		PostUnlock(m)
 	}
-	m.mu.RUnlock()
 }
 
 // RLocker returns a Locker interface that implements


### PR DESCRIPTION
Is it mistake?
Currently, deadlock.RLock executes PostUnlock before RUnlock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/10)
<!-- Reviewable:end -->
