### PR TITLE
add var ENABLE_DETECT; add sleep for default OnPotentialDeadlock whic…

### DIFF
--- a/deadlock.go
+++ b/deadlock.go
@@ -123,7 +123,7 @@ func (m *RWMutex) Unlock() {
 	m.mu.Unlock()
 	if ENABLE_DETECT {
 		if !Opts.Disable {
-			PostUnlock(m)
+			postUnlock(m)
 		}
 	}
 }


### PR DESCRIPTION
1. add var ENABLE_DETECT to switch raw mutex and this deadlock  
2. add sleep for default OnPotentialDeadlock which let all error can dump

eg:

var mp map[int]bool
var b Mutex //deadlock mutext
go func() {
for{
b.Lock()
mp[1] = true
b.Unlock()
}
}()

go func(){
 for{
b.Lock()
fmt.Println("this may cannot be print, and only deadlock detection will be dump")
b.Unlock()

}
}()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/11)
<!-- Reviewable:end -->
