### PR TITLE
Add wrappers for all other sync.* types

### DIFF
--- a/deadlock.go
+++ b/deadlock.go
@@ -44,6 +44,36 @@ var Opts = struct {
 	LogBuf:     os.Stderr,
 }
 
+// Cond is sync.Cond wrapper
+type Cond struct {
+	sync.Cond
+}
+
+// Locker is sync.Locker wrapper
+type Locker struct {
+	sync.Locker
+}
+
+// Map is sync.Map wrapper
+type Map struct {
+	sync.Map
+}
+
+// Once is sync.Once wrapper
+type Once struct {
+	sync.Once
+}
+
+// Pool is sync.Poll wrapper
+type Pool struct {
+	sync.Pool
+}
+
+// WaitGroup is sync.WaitGroup wrapper
+type WaitGroup struct {
+	sync.WaitGroup
+}
+
 // A Mutex is a drop-in replacement for sync.Mutex.
 // Performs deadlock detection unless disabled in Opts.
 type Mutex struct {


### PR DESCRIPTION
Wrap all remaining sync.* types to allow just replace
```golang
import (
  "sync"
)
```
with
```golang
import (
  sync "github.com/sasha-s/go-deadlock"
)
```
for all testing purposes and switch back easily in final product

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/13)
<!-- Reviewable:end -->
