### PR TITLE
AddingPowerSupport_For_golang-github-sasha-s-go-deadlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 sudo: false
 go:


### PR DESCRIPTION
Adding Power Support.

Adding power support ppc64le
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful for both arch: amd64/ppc64le. Here is the travis link: https://travis-ci.com/github/santosh653/go-deadlock

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/20)
<!-- Reviewable:end -->
