### PR TITLE
Add missing sync.NewCond wrapper

### DIFF
--- a/deadlock.go
+++ b/deadlock.go
@@ -69,6 +69,9 @@ type WaitGroup struct {
 	sync.WaitGroup
 }
 
+// NewCond is a sync.NewCond wrapper
+var NewCond = sync.NewCond
+
 // A Mutex is a drop-in replacement for sync.Mutex.
 // Performs deadlock detection unless disabled in Opts.
 type Mutex struct {


### PR DESCRIPTION
I noticed recently while integrating go-deadlock that it was missing a wrapper for sync.NewCond.

Here is a little patch to add it.

Thank you for a great package :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/22)
<!-- Reviewable:end -->
