### PR TITLE
Reuse timers with sync.Pool

### DIFF
--- a/alloc_test.go
+++ b/alloc_test.go
@@ -1,0 +1,13 @@
+package deadlock
+
+import (
+	"testing"
+)
+
+func BenchmarkCheckDeadlock(b *testing.B) {
+	ch := make(chan struct{})
+	close(ch)
+	for i := 0; i < b.N; i++ {
+		checkDeadlock(nil, nil, 0, ch)
+	}
+}

--- a/deadlock.go
+++ b/deadlock.go
@@ -182,60 +182,81 @@ func lock(lockFn func(), ptr interface{}) {
 	} else {
 		ch := make(chan struct{})
 		currentID := goid.Get()
-		go func() {
-			for {
-				t := time.NewTimer(Opts.DeadlockTimeout)
-				defer t.Stop() // This runs after the losure finishes, but it's OK.
-				select {
-				case <-t.C:
-					lo.mu.Lock()
-					prev, ok := lo.cur[ptr]
-					if !ok {
-						lo.mu.Unlock()
-						break // Nobody seems to be holding the lock, try again.
-					}
-					Opts.mu.Lock()
-					fmt.Fprintln(Opts.LogBuf, header)
-					fmt.Fprintln(Opts.LogBuf, "Previous place where the lock was grabbed")
-					fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p\n", prev.gid, ptr)
-					printStack(Opts.LogBuf, prev.stack)
-					fmt.Fprintln(Opts.LogBuf, "Have been trying to lock it again for more than", Opts.DeadlockTimeout)
-					fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p\n", currentID, ptr)
-					printStack(Opts.LogBuf, stack)
-					stacks := stacks()
-					grs := bytes.Split(stacks, []byte("\n\n"))
-					for _, g := range grs {
-						if goid.ExtractGID(g) == prev.gid {
-							fmt.Fprintln(Opts.LogBuf, "Here is what goroutine", prev.gid, "doing now")
-							Opts.LogBuf.Write(g)
-							fmt.Fprintln(Opts.LogBuf)
-						}
-					}
-					lo.other(ptr)
-					if Opts.PrintAllCurrentGoroutines {
-						fmt.Fprintln(Opts.LogBuf, "All current goroutines:")
-						Opts.LogBuf.Write(stacks)
-					}
-					fmt.Fprintln(Opts.LogBuf)
-					if buf, ok := Opts.LogBuf.(*bufio.Writer); ok {
-						buf.Flush()
-					}
-					Opts.mu.Unlock()
-					lo.mu.Unlock()
-					Opts.OnPotentialDeadlock()
-					<-ch
-					return
-				case <-ch:
-					return
-				}
-			}
-		}()
+		go checkDeadlock(stack, ptr, currentID, ch)
 		lockFn()
 		postLock(stack, ptr)
 		close(ch)
 		return
 	}
 	postLock(stack, ptr)
+}
+
+var timersPool sync.Pool
+
+func acquireTimer(d time.Duration) *time.Timer {
+	t, ok := timersPool.Get().(*time.Timer)
+	if ok {
+		_ = t.Reset(d)
+		return t
+	}
+	return time.NewTimer(Opts.DeadlockTimeout)
+}
+
+func releaseTimer(t *time.Timer) {
+	if !t.Stop() {
+		<-t.C
+	}
+	timersPool.Put(t)
+}
+
+func checkDeadlock(stack []uintptr, ptr interface{}, currentID int64, ch <-chan struct{}) {
+	t := acquireTimer(Opts.DeadlockTimeout)
+	defer releaseTimer(t)
+	for {
+		select {
+		case <-t.C:
+			lo.mu.Lock()
+			prev, ok := lo.cur[ptr]
+			if !ok {
+				lo.mu.Unlock()
+				break // Nobody seems to be holding the lock, try again.
+			}
+			Opts.mu.Lock()
+			fmt.Fprintln(Opts.LogBuf, header)
+			fmt.Fprintln(Opts.LogBuf, "Previous place where the lock was grabbed")
+			fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p\n", prev.gid, ptr)
+			printStack(Opts.LogBuf, prev.stack)
+			fmt.Fprintln(Opts.LogBuf, "Have been trying to lock it again for more than", Opts.DeadlockTimeout)
+			fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p\n", currentID, ptr)
+			printStack(Opts.LogBuf, stack)
+			stacks := stacks()
+			grs := bytes.Split(stacks, []byte("\n\n"))
+			for _, g := range grs {
+				if goid.ExtractGID(g) == prev.gid {
+					fmt.Fprintln(Opts.LogBuf, "Here is what goroutine", prev.gid, "doing now")
+					Opts.LogBuf.Write(g)
+					fmt.Fprintln(Opts.LogBuf)
+				}
+			}
+			lo.other(ptr)
+			if Opts.PrintAllCurrentGoroutines {
+				fmt.Fprintln(Opts.LogBuf, "All current goroutines:")
+				Opts.LogBuf.Write(stacks)
+			}
+			fmt.Fprintln(Opts.LogBuf)
+			if buf, ok := Opts.LogBuf.(*bufio.Writer); ok {
+				buf.Flush()
+			}
+			Opts.mu.Unlock()
+			lo.mu.Unlock()
+			Opts.OnPotentialDeadlock()
+			<-ch
+			return
+		case <-ch:
+			return
+		}
+		t.Reset(Opts.DeadlockTimeout)
+	}
 }
 
 type lockOrder struct {


### PR DESCRIPTION
Here is the top out for alloc space of heap profile:
```
      flat  flat%   sum%        cum   cum%
 5845.32MB 42.91% 42.91%  5845.32MB 42.91%  github.com/sasha-s/go-deadlock.callers (inline)
 2851.22MB 20.93% 63.84%  2851.22MB 20.93%  time.NewTimer
 2243.68MB 16.47% 80.32%  8089.69MB 59.39%  github.com/sasha-s/go-deadlock.lock
```
I haven't figured out how to optimize `callers`. But for `time.NewTimer` the change seemed to be quite simple. So I made it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/31)
<!-- Reviewable:end -->
