### PR TITLE
Go 1.25 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,7 @@ jobs:
           - "1.20"
           - "1.22"
           - "1.23"
+          - "1.25"
     steps:
       - uses: actions/checkout@v4
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sasha-s/go-deadlock
 
-require github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7
+require github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 h1:Dx7Ovyv/SFnMFw3fD4oEoeorXc6saIiQ23LrGLth0Gw=
-github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=
+github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe h1:vHpqOnPlnkba8iSxU4j/CvDSS9J4+F4473esQsYLGoE=
+github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe/go.mod h1:pxMtw7cyUw6B2bRH0ZBANSPg+AoSud1I1iyJHI69jH4=


### PR DESCRIPTION
Bumps `github.com/petermattis/goid`, adds Go 1.25 to CI.