### PR TITLE
fix: use weak pointers in lock order map to prevent GC leak (#46)

### DIFF
--- a/beforeafter_go124.go
+++ b/beforeafter_go124.go
@@ -1,0 +1,30 @@
+//go:build go1.24
+
+package deadlock
+
+import (
+	"unsafe"
+	"weak"
+)
+
+type beforeAfter struct {
+	before weak.Pointer[byte]
+	after  weak.Pointer[byte]
+}
+
+// ptrFromInterface extracts the data pointer from an interface{} value.
+// An interface (eface) is {type *_type, data unsafe.Pointer}; we grab the second word.
+func ptrFromInterface(i interface{}) *byte {
+	type eface struct {
+		_    uintptr
+		data unsafe.Pointer
+	}
+	return (*byte)((*eface)(unsafe.Pointer(&i)).data)
+}
+
+func newBeforeAfter(before, after interface{}) beforeAfter {
+	return beforeAfter{
+		before: weak.Make(ptrFromInterface(before)),
+		after:  weak.Make(ptrFromInterface(after)),
+	}
+}

--- a/beforeafter_legacy.go
+++ b/beforeafter_legacy.go
@@ -1,0 +1,12 @@
+//go:build !go1.24
+
+package deadlock
+
+type beforeAfter struct {
+	before interface{}
+	after  interface{}
+}
+
+func newBeforeAfter(before, after interface{}) beforeAfter {
+	return beforeAfter{before: before, after: after}
+}

--- a/deadlock.go
+++ b/deadlock.go
@@ -308,11 +308,6 @@ type stackGID struct {
 	gid   int64
 }
 
-type beforeAfter struct {
-	before interface{}
-	after  interface{}
-}
-
 type ss struct {
 	before []uintptr
 	after  []uintptr
@@ -365,7 +360,7 @@ func (l *lockOrder) preLock(stack []uintptr, p interface{}) {
 			if bs.gid != gid { // We want locks taken in the same goroutine only.
 				continue
 			}
-			if s, ok := l.order[beforeAfter{p, b}]; ok {
+			if s, ok := l.order[newBeforeAfter(p, b)]; ok {
 				Opts.mu.Lock()
 				fmt.Fprintln(Opts.LogBuf, header, "Inconsistent locking. saw this ordering in one goroutine:")
 				fmt.Fprintln(Opts.LogBuf, "happened before")
@@ -384,7 +379,7 @@ func (l *lockOrder) preLock(stack []uintptr, p interface{}) {
 				Opts.mu.Unlock()
 				Opts.OnPotentialDeadlock()
 			}
-			l.order[beforeAfter{b, p}] = ss{bs.stack, stack}
+			l.order[newBeforeAfter(b, p)] = ss{bs.stack, stack}
 			if len(l.order) == Opts.MaxMapSize { // Reset the map to keep memory footprint bounded.
 				l.order = map[beforeAfter]ss{}
 			}

--- a/gc_go124_test.go
+++ b/gc_go124_test.go
@@ -1,0 +1,37 @@
+//go:build go1.24
+
+package deadlock
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestOrderMapGC(t *testing.T) {
+	Opts.DeadlockTimeout = 0
+	Opts.OnPotentialDeadlock = func() {}
+	defer func() {
+		Opts.DeadlockTimeout = 30e9
+		Opts.OnPotentialDeadlock = func() { panic("deadlock") }
+	}()
+
+	var anchor Mutex
+	for i := 0; i < 50; i++ {
+		h := &HeavyStruct{}
+		h.data[0] = byte(i)
+		anchor.Lock()
+		h.Lock()
+		h.Unlock()
+		anchor.Unlock()
+	}
+
+	runtime.GC()
+	runtime.GC()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	t.Logf("HeapInuse: %d MB", ms.HeapInuse/(1024*1024))
+	if ms.HeapInuse > 20*1024*1024 {
+		t.Errorf("Memory leak: HeapInuse = %d MB, expected < 20 MB. Lock order map retains references.", ms.HeapInuse/(1024*1024))
+	}
+}

--- a/gc_legacy_test.go
+++ b/gc_legacy_test.go
@@ -1,0 +1,37 @@
+//go:build !go1.24
+
+package deadlock
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestOrderMapGCLegacy documents that on Go < 1.24 the lock order map retains
+// strong references to mutexes, preventing GC. This is a known limitation
+// fixed by weak pointers available in Go 1.24+.
+func TestOrderMapGCLegacy(t *testing.T) {
+	Opts.DeadlockTimeout = 0
+	Opts.OnPotentialDeadlock = func() {}
+	defer func() {
+		Opts.DeadlockTimeout = 30e9
+		Opts.OnPotentialDeadlock = func() { panic("deadlock") }
+	}()
+
+	var anchor Mutex
+	for i := 0; i < 50; i++ {
+		h := &HeavyStruct{}
+		h.data[0] = byte(i)
+		anchor.Lock()
+		h.Lock()
+		h.Unlock()
+		anchor.Unlock()
+	}
+
+	runtime.GC()
+	runtime.GC()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	t.Logf("HeapInuse: %d MB (known leak on Go < 1.24)", ms.HeapInuse/(1024*1024))
+}

--- a/gc_test.go
+++ b/gc_test.go
@@ -1,0 +1,8 @@
+package deadlock
+
+// HeavyStruct is used by GC-related tests to verify that lock order tracking
+// does not prevent garbage collection of structs containing deadlock.Mutex.
+type HeavyStruct struct {
+	Mutex
+	data [1024 * 1024]byte
+}


### PR DESCRIPTION
## Summary
- `beforeAfter` map keys held strong `interface{}` references to every mutex, preventing GC of containing structs
- On Go 1.24+, use `weak.Pointer[byte]` which preserves map key equality but allows GC
- Pre-1.24 retains current behavior via build tags

Fixes #46

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/49)
<!-- Reviewable:end -->
