### PR TITLE
go.mod: remove `replace` directive, and declare Go 1.17 as minimum version 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sasha-s/go-deadlock
 
+go 1.17
+
 require github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/sasha-s/go-deadlock
 
 require github.com/petermattis/goid v0.0.0-20250813065127-a731cc31b4fe
-
-replace github.com/sasha-s/go-deadlock => /src/go-deadlock


### PR DESCRIPTION
- relates to https://github.com/sasha-s/go-deadlock/pull/42

### go.mod: remove replace directive

This replace directive was added in d3f39e3d50d9afab86c8f13125a8e08c04e413c4,
and may have been for testing, and accidentally left behind.


### go.mod: declare Go 1.17 as minimum version

Go 1.17 is the oldest version covered by CI. Declare it explicitly to avoid
Go tooling adding the currently installed toolchain version when updating the
module file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sasha-s/go-deadlock/56)
<!-- Reviewable:end -->
